### PR TITLE
Add credential support

### DIFF
--- a/rightscale/data_source_credential.go
+++ b/rightscale/data_source_credential.go
@@ -1,0 +1,103 @@
+package rightscale
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+)
+
+// Example:
+//
+// data "rightscale_credential" "account_aws_access_key_id" {
+//   filter {
+//     name = "AWS_ACCESS_KEY_ID"
+//   }
+// }
+
+func dataSourceCredential() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceCredentialRead,
+
+		Schema: map[string]*schema.Schema{
+			"view": {
+				Type:         schema.TypeString,
+				Description:  "Filter at api level for the view: 'default' or 'sensitive' are valid options",
+				Optional:     true,
+				Default:      "sensitive",
+				ValidateFunc: validation.StringInSlice([]string{"default", "sensitive"}, false),
+			},
+			"filter": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "name of credential, uses partial match",
+							Optional:    true,
+							ForceNew:    true,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Description: "description of credential",
+							Optional:    true,
+							ForceNew:    true,
+						},
+					},
+				},
+			},
+
+			// Read-only fields
+			"links": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourceCredentialRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(rsc.Client)
+	acParams := make(map[string]string)
+	acParams["view"] = d.Get("view").(string)
+
+	loc := &rsc.Locator{Namespace: "rs_cm", Type: "credential", ActionParams: acParams}
+
+	res, err := client.List(loc, "credential", cmFilters(d))
+	if err != nil {
+		return err
+	}
+
+	if len(res) == 0 {
+		return nil
+	}
+	for k, v := range res[0].Fields {
+		d.Set(k, v)
+	}
+	d.SetId(res[0].Locator.Href)
+	return nil
+}

--- a/rightscale/provider.go
+++ b/rightscale/provider.go
@@ -31,6 +31,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"rightscale_cloud":             dataSourceCloud(),
+			"rightscale_credential":        dataSourceCredential(),
 			"rightscale_datacenter":        dataSourceDatacenter(),
 			"rightscale_image":             dataSourceImage(),
 			"rightscale_instance":          dataSourceInstance(),
@@ -59,6 +60,7 @@ func Provider() terraform.ResourceProvider {
 			"rightscale_ssh_key":             resourceSSHKey(),
 			"rightscale_subnet":              resourceSubnet(),
 			"rightscale_cwf_process":         resourceCWFProcess(),
+			"rightscale_credential":          resourceCredential(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/rightscale/resource_credential.go
+++ b/rightscale/resource_credential.go
@@ -9,7 +9,7 @@ import (
 //
 // resource "rightscale_credential" "database_password" {
 //   name = "DATABASE_PASSWORD"
-//	 value = "password11"
+//	 value = "rightscale11"
 //	 description = "Top Secret database password"
 // }
 

--- a/rightscale/resource_credential.go
+++ b/rightscale/resource_credential.go
@@ -1,0 +1,87 @@
+package rightscale
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/rightscale/terraform-provider-rightscale/rightscale/rsc"
+)
+
+// Example:
+//
+// resource "rightscale_credential" "database_password" {
+//   name = "DATABASE_PASSWORD"
+//	 value = "password11"
+//	 description = "Top Secret database password"
+// }
+
+func resourceCredential() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceCredentialRead,
+		Exists: resourceExists,
+		Delete: resourceDelete,
+		Create: resourceCreateFunc("rs_cm", "credentials", credentialWriteFields),
+		Update: resourceUpdateFunc(credentialWriteFields),
+
+		Schema: map[string]*schema.Schema{
+			"description": &schema.Schema{
+				Description: "description of the credential object",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"name": &schema.Schema{
+				Description: "name of the credential object",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+			"value": &schema.Schema{
+				Description: "value of the credential object",
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"links": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func credentialWriteFields(d *schema.ResourceData) rsc.Fields {
+	fields := rsc.Fields{}
+	fieldopts := []string{"name", "value", "description"}
+	for _, f := range fieldopts {
+		if v, ok := d.GetOk(f); ok {
+			fields[f] = v
+		}
+	}
+	return rsc.Fields{"credential": fields}
+}
+
+func resourceCredentialRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(rsc.Client)
+	loc, err := locator(d)
+	if err != nil {
+		return err
+	}
+
+	// set ActionParams Locator to always read this resource (currently) with 'view: "sensitive"'
+	loc.ActionParams = map[string]string{"view": "sensitive"}
+
+	res, err := client.Get(loc)
+	if err != nil {
+		return handleRSCError(d, err)
+	}
+	for k, v := range res.Fields {
+		d.Set(k, v)
+	}
+	return nil
+}

--- a/rightscale/resource_credential_test.go
+++ b/rightscale/resource_credential_test.go
@@ -1,0 +1,101 @@
+package rightscale
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rightscale/rsc/cm15"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccRightScaleCredential_basic(t *testing.T) {
+	t.Parallel()
+
+	var (
+		credentialName        = "terraform-test-credential-" + testString + "-" + acctest.RandString(10)
+		credentialValue       = "thisIsATest_thisIsOnlyATest"
+		credentialDescription = "A test cred created by the rs tf provider"
+		credential            cm15.Credential
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCredentialDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCredential_basic(credentialName, credentialValue, credentialDescription),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCredentialExists("rightscale_credential.credential_test", &credential),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCredentialExists(n string, credential *cm15.Credential) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		loc := getCMClient().CredentialLocator(getHrefFromID(rs.Primary.ID))
+
+		found, err := loc.Show(nil)
+		if err != nil {
+			return err
+		}
+
+		*credential = *found
+
+		return nil
+	}
+}
+
+func testAccCheckCredentialDestroy(s *terraform.State) error {
+	c := getCMClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rightscale_credential" {
+			continue
+		}
+
+		loc := c.CredentialLocator(getHrefFromID(rs.Primary.ID))
+		credentials, err := loc.Index(nil)
+		if err != nil {
+			return fmt.Errorf("failed to check for existence of credential: %s", err)
+		}
+		found := false
+		self := strings.Split(rs.Primary.ID, ":")[1]
+		for _, key := range credentials {
+			if string(key.Locator(c).Href) == self {
+				found = true
+				break
+			}
+		}
+		if found {
+			return fmt.Errorf("credential still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCredential_basic(name string, value string, description string) string {
+	return fmt.Sprintf(`
+resource "rightscale_credential" "credential_test" {
+	name              = %q
+	value	          = %q
+	description		  = %q
+}
+`, name, value, description)
+}

--- a/website/docs/d/cm_credential.markdown
+++ b/website/docs/d/cm_credential.markdown
@@ -1,0 +1,53 @@
+---
+layout: "rightscale"
+page_title: "Rightscale: credential"
+sidebar_current: "docs-rightscale-datasource-credential"
+description: |-
+  Defines a credential datasource to operate against. 
+---
+
+# rightscale_credential
+
+Use this data source to locate and extract the data of an existing credential to pass to other rightscale resources, or to access the values.  Viewing values of credentials assumes requisite account permission levels.
+
+## Example Usage: Access credential value
+
+```hcl
+data "rightscale_credential" "account_aws_access_key_id" {
+  filter {
+    name = "AWS_ACCESS_KEY_ID"
+  }
+}
+
+output "my-aws-access-key-id" {
+  value = "${data.rightscale_credential.account_aws_access_key_id.value}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `view` - (Optional) Set this to 'default' to NOT request credential value with api response.  This allows use of existing credential with other rightscale provider resources (extracting href and handing to other resources). Offereed in case user lacks rs account privs sufficient to view credential values. 
+
+The `filter` block supports:
+
+* `name` - (Optional) Credential name.  Pattern match. 
+
+* `description` - (Optional) Description of credential.  Pattern match.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - Name of the credential.
+
+* `description` - Description of the credential.
+
+* `value` - (Contextual) Available unless if 'default' view is set.  Value of the credential.
+
+* `links` - Hrefs of related API resources.
+
+* `created_at` - Datestamp of credential creation.
+
+* `updated_at` - Datestamp of when credential was updated last.

--- a/website/docs/r/cm_credential.markdown
+++ b/website/docs/r/cm_credential.markdown
@@ -1,0 +1,47 @@
+---
+layout: "rightscale"
+page_title: "Rightscale: credential"
+sidebar_current: "docs-rightscale-resource-credential"
+description: |-
+  Create and maintain a rightscale credential resource.
+---
+
+# rightscale_credential
+
+Use this resource to create, read, update or destroy rightscale credential objects.
+
+## Example Usage
+
+```hcl
+resource "rightscale_credential" "database_password" {
+  name = "DATABASE_PASSWORD"
+  value = "rightscale11"
+  description = "Top Secret database password"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the credential.
+
+* `value` - (Required) Value of the credential.
+
+* `description` - (Optional) Description of the credential.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - Name of the credential.
+
+* `description` - Description of the credential.
+
+* `value` - Value of the credential. 
+
+* `links` - Hrefs of related API resources.
+
+* `created_at` - Datestamp of credential creation.
+
+* `updated_at` - Datestamp of when credential was updated last.


### PR DESCRIPTION
Adds rightscale [Credential](http://docs.rightscale.com/cm/dashboard/design/credentials/) object support as a resource and datastore, including tests and documentation.