### PR TITLE
STEEL-232 substitute travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,16 @@ script:
   # Only run acceptance tests if :
   #   RIGHTSCALE_API_TOKEN is set up (encrypted variable not available from external PRs, avoids false red builds)
   #   ... and only for master / merge to master builds - launching instances and stuff is pricy!
+  # Output something every 10 minutes or Travis kills the job
+  - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
   - |
     if [[ ! -z "$RIGHTSCALE_API_TOKEN" && $TRAVIS_BRANCH =~ ^master$ ]]; then
-      travis_wait make testacc;
+      make testacc;
     else
       echo "SKIPPING acceptance tests since RIGHTSCALE_API_TOKEN not set and/or TRAVIS_BRANCH is not master";
     fi
+  # Killing background sleep loop
+  - kill %1
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
For some reason travis_wait is not doing its job and the build times out

Also with this solution, "stolen" from https://github.com/travis-ci/travis-ci/issues/4190 , shows the "slow command" output as it happens (travis_wait shows the whole output when the "slow command" finishes)